### PR TITLE
Implement `getCurrentLoggedInUsersId()` (Close #8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 

--- a/src/main/java/com/seyed/ali/timeentryservice/client/AuthenticationServiceClient.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/client/AuthenticationServiceClient.java
@@ -1,14 +1,53 @@
 package com.seyed.ali.timeentryservice.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seyed.ali.timeentryservice.keycloak.util.KeycloakSecurityUtil;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Component
 @RequiredArgsConstructor
 public class AuthenticationServiceClient {
 
+    private @Value("${authentication.service.user-persistence-controller.base-url}") String authenticationServiceClient_BaseUrl;
+    private @Value("${authentication.service.user-persistence-controller.handle-user-url}") String authenticationServiceClient_HandleUserUrl;
+
+    private final WebClient.Builder webClientBuilder;
+    private final KeycloakSecurityUtil keycloakSecurityUtil;
+    private final ObjectMapper objectMapper;
+    private WebClient webClient;
+
+    @PostConstruct
+    public void init() {
+        this.webClient = this.webClientBuilder
+                .baseUrl(this.authenticationServiceClient_BaseUrl)
+                .build();
+    }
+
+    // TODO: Cache this method in REDIS
     public String getCurrentLoggedInUsersId() {
-        return null;
+        String jwtToken = this.keycloakSecurityUtil.extractTokenFromSecurityContext();
+        String userJson = this.webClient
+                .post().uri(this.authenticationServiceClient_HandleUserUrl)
+                .header(AUTHORIZATION, "Bearer " + jwtToken)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+        String userId;
+        try {
+            JsonNode jsonNode = this.objectMapper.readTree(userJson);
+            userId = jsonNode.get("id").asText();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return userId;
     }
 
 }

--- a/src/main/java/com/seyed/ali/timeentryservice/config/webclient/WebClientConfiguration.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/config/webclient/WebClientConfiguration.java
@@ -1,0 +1,15 @@
+package com.seyed.ali.timeentryservice.config.webclient;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfiguration {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+
+}

--- a/src/main/java/com/seyed/ali/timeentryservice/keycloak/util/KeycloakSecurityUtil.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/keycloak/util/KeycloakSecurityUtil.java
@@ -2,9 +2,12 @@ package com.seyed.ali.timeentryservice.keycloak.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -58,6 +61,14 @@ public class KeycloakSecurityUtil {
         }
 
         return authorities;
+    }
+
+    public String extractTokenFromSecurityContext() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof JwtAuthenticationToken jwtAuthenticationToken) {
+            return jwtAuthenticationToken.getToken().getTokenValue();
+        }
+        throw new IllegalStateException("No JWT token found in security context");
     }
 
 }

--- a/src/main/java/com/seyed/ali/timeentryservice/service/TimeEntryServiceImpl.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/service/TimeEntryServiceImpl.java
@@ -5,8 +5,8 @@ import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
 import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
 import com.seyed.ali.timeentryservice.repository.TimeEntryRepository;
 import com.seyed.ali.timeentryservice.service.interfaces.TimeEntryService;
+import com.seyed.ali.timeentryservice.util.TimeEntryServiceUtility;
 import com.seyed.ali.timeentryservice.util.TimeParser;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -14,16 +14,22 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
-public class TimeEntryServiceImpl implements TimeEntryService {
+public class TimeEntryServiceImpl extends TimeEntryServiceUtility implements TimeEntryService {
 
     private final TimeEntryRepository timeEntryRepository;
-    private final AuthenticationServiceClient authenticationServiceClient;
     private final TimeParser timeParser;
+
+    public TimeEntryServiceImpl(AuthenticationServiceClient authenticationServiceClient,
+                                TimeParser timeParser,
+                                TimeEntryRepository timeEntryRepository,
+                                TimeParser parser) {
+        super(authenticationServiceClient, timeParser);
+        this.timeEntryRepository = timeEntryRepository;
+        this.timeParser = parser;
+    }
 
     @Override
     public List<TimeEntryDTO> getTimeEntries() {
@@ -51,33 +57,6 @@ public class TimeEntryServiceImpl implements TimeEntryService {
         TimeEntry timeEntry = createTimeEntry(timeEntryDTO);
         this.timeEntryRepository.save(timeEntry);
         return this.timeParser.parseTimeToString(timeEntry.getStartTime(), timeEntry.getEndTime(), timeEntry.getDuration());
-    }
-
-    // TODO
-    private TimeEntry createTimeEntry(TimeEntryDTO timeEntryDTO) {
-        TimeEntry timeEntry = new TimeEntry();
-        timeEntry.setId(UUID.randomUUID().toString());
-
-        LocalDateTime startTime = this.timeParser.parseStringToLocalDateTime(timeEntryDTO.startTime());
-        LocalDateTime endTime = this.timeParser.parseStringToLocalDateTime(timeEntryDTO.endTime());
-        Duration calculatedDuration = Duration.between(startTime, endTime);
-
-        // if the user entered `duration` field
-        Optional<Duration> durationOpt = Optional.ofNullable(timeEntryDTO.duration())
-                .map(this.timeParser::parseStringToDuration);
-
-        durationOpt.ifPresent(duration -> {
-            if (!calculatedDuration.equals(duration)) {
-                throw new IllegalArgumentException("The provided endTime and duration are not consistent with the startTime");
-            }
-        });
-
-        timeEntry.setStartTime(startTime);
-        timeEntry.setEndTime(endTime);
-        timeEntry.setDuration(calculatedDuration);
-        timeEntry.setUserId(this.authenticationServiceClient.getCurrentLoggedInUsersId());
-
-        return timeEntry;
     }
 
     @Override

--- a/src/main/java/com/seyed/ali/timeentryservice/util/TimeEntryServiceUtility.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/util/TimeEntryServiceUtility.java
@@ -1,0 +1,45 @@
+package com.seyed.ali.timeentryservice.util;
+
+import com.seyed.ali.timeentryservice.client.AuthenticationServiceClient;
+import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
+import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public abstract class TimeEntryServiceUtility {
+
+    private final AuthenticationServiceClient authenticationServiceClient;
+    private final TimeParser timeParser;
+
+    public TimeEntry createTimeEntry(TimeEntryDTO timeEntryDTO) {
+        TimeEntry timeEntry = new TimeEntry();
+        timeEntry.setId(UUID.randomUUID().toString());
+
+        LocalDateTime startTime = this.timeParser.parseStringToLocalDateTime(timeEntryDTO.startTime());
+        LocalDateTime endTime = this.timeParser.parseStringToLocalDateTime(timeEntryDTO.endTime());
+        Duration calculatedDuration = Duration.between(startTime, endTime);
+
+        // if the user entered `duration` field
+        Optional<Duration> durationOpt = Optional.ofNullable(timeEntryDTO.duration())
+                .map(this.timeParser::parseStringToDuration);
+
+        durationOpt.ifPresent(duration -> {
+            if (!calculatedDuration.equals(duration)) {
+                throw new IllegalArgumentException("The provided endTime and duration are not consistent with the startTime");
+            }
+        });
+
+        timeEntry.setStartTime(startTime);
+        timeEntry.setEndTime(endTime);
+        timeEntry.setDuration(calculatedDuration);
+        timeEntry.setUserId(this.authenticationServiceClient.getCurrentLoggedInUsersId());
+
+        return timeEntry;
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -50,3 +50,10 @@ springdoc:
     oauth:
       client-id: ${KEYCLOAK_CLIENT_ID}
       client-secret: ${KEYCLOAK_CLIENT_SECRET}
+
+--- # Custom Variables
+authentication:
+  service:
+    user-persistence-controller:
+      base-url: http://${AUTHENTICATION_SERVICE_HANDLE_USER_BASE_URL:localhost:8081}/keycloak-user
+      handle-user-url: /handle-user

--- a/src/test/java/com/seyed/ali/timeentryservice/client/AuthenticationServiceClientTest.java
+++ b/src/test/java/com/seyed/ali/timeentryservice/client/AuthenticationServiceClientTest.java
@@ -1,0 +1,103 @@
+package com.seyed.ali.timeentryservice.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.seyed.ali.timeentryservice.keycloak.util.KeycloakSecurityUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationServiceClientTest {
+
+    private @InjectMocks AuthenticationServiceClient authenticationServiceClient;
+    private @Mock WebClient.Builder webClientBuilder;
+    private @Mock WebClient webClient;
+    private @Mock KeycloakSecurityUtil keycloakSecurityUtil;
+    private @Mock ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() throws NoSuchFieldException, IllegalAccessException {
+        // inject @Value(..) fields
+        Field authenticationServiceClient_BaseUrl_Field = AuthenticationServiceClient.class // the service class
+                .getDeclaredField("authenticationServiceClient_BaseUrl"); // the @Value field
+        authenticationServiceClient_BaseUrl_Field.setAccessible(true);
+        authenticationServiceClient_BaseUrl_Field.set(this.authenticationServiceClient, "some_base_url");
+
+        Field authenticationServiceClient_HandleUserUrl_Field = AuthenticationServiceClient.class
+                .getDeclaredField("authenticationServiceClient_HandleUserUrl");
+        authenticationServiceClient_HandleUserUrl_Field.setAccessible(true);
+        authenticationServiceClient_HandleUserUrl_Field.set(this.authenticationServiceClient, "some_handle_user_url");
+
+        // mocking `WebClientBuilder#baseUrl(String)`
+        when(this.webClientBuilder.baseUrl(isA(String.class)))
+                .thenReturn(this.webClientBuilder);
+
+        // mocking `WebClientBuilder#build()`
+        when(this.webClientBuilder.build())
+                .thenReturn(this.webClient);
+
+        // mocking `WebClient#post()`
+        WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+        when(this.webClient.post())
+                .thenReturn(requestBodyUriSpec);
+
+        // mocking `WebClient#post()`
+        WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+        when(requestBodyUriSpec.uri(isA(String.class)))
+                .thenReturn(requestBodySpec);
+
+        // mocking `RequestHeadersSpec#header(String, String)`
+        when(requestBodySpec.header(eq("Authorization"), isA(String.class)))
+                .thenReturn(requestBodySpec);
+
+        // mocking `RequestHeadersSpec#retrieve()`
+        WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+        when(requestBodySpec.retrieve())
+                .thenReturn(responseSpec);
+
+        // mocking `ResponseSpec#bodyToMono(String)`
+        when(responseSpec.bodyToMono(String.class))
+                .thenReturn(Mono.just("{\"id\":\"123\"}"));
+
+        /*
+         * The @PostConstruct annotation is used on a method that needs to be executed after dependency injection is done to perform any initialization.
+         * In our `AuthenticationServiceClient` class, the `WebClient` instance is being initialized in a `@PostConstruct` annotated method.
+         * In the test, Mockito creates a mock of the class before the `@PostConstruct` method is called, so the `WebClient` instance is not initialized,
+         * and that’s why we'll get a `NullPointerException`.
+         * To solve this, we will manually call the init() method in the `@BeforeEach` annotated method in our test class after the mocks are created.
+         */
+        this.authenticationServiceClient.init();
+    }
+
+    @Test
+    public void getCurrentLoggedInUsersIdTest() throws JsonProcessingException {
+        // given
+        when(this.keycloakSecurityUtil.extractTokenFromSecurityContext())
+                .thenReturn("dummyToken");
+        when(this.objectMapper.readTree(isA(String.class)))
+                .thenReturn(JsonNodeFactory.instance.objectNode().put("id", "123"));
+
+        // when
+        String userId = this.authenticationServiceClient.getCurrentLoggedInUsersId();
+        System.out.println(userId);
+
+        // then
+        assertEquals("123", userId);
+    }
+
+}

--- a/src/test/java/com/seyed/ali/timeentryservice/controller/TestControllerTest.java
+++ b/src/test/java/com/seyed/ali/timeentryservice/controller/TestControllerTest.java
@@ -28,9 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {EurekaClientTestConfiguration.class}) /* to call the configuration in the test (for service-registry configs) */
 public class TestControllerTest {
 
-    //<editor-fold desc="fields">
     private @Autowired MockMvc mockMvc;
-    //</editor-fold>
 
     @Test
     public void helloTest() throws Exception {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,3 +32,10 @@ springdoc:
     oauth:
       client-id: ${KEYCLOAK_CLIENT_ID} # fill this data otherwise `mvn clean install` won't succeed.
       client-secret: ${KEYCLOAK_CLIENT_SECRET} # fill this data otherwise `mvn clean install` won't succeed.
+
+--- # Custom Variables
+authentication:
+  service:
+    user-persistence-controller:
+      base-url: http://${AUTHENTICATION_SERVICE_HANDLE_USER_BASE_URL:localhost:8081}/keycloak-user
+      handle-user-url: /handle-user


### PR DESCRIPTION
Implemented the `AuthenticationServiceClient#getCurrentLoggedInUsersId` method in the authentication service client. This method returns the ID of the currently logged-in user. The method uses the `Authentication-Service#handleUser(Jwt)` to retrieve the user's ID. The method has been tested with unit tests.

> Note: This method, needs to be cached using redis. Implement it later on.