### PR TITLE
Feature/redis state management - Close #13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 
 ### Environment Variables ###
 src/main/resources/.env.properties
+
+### DB Data ###
+db/redis/

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
 
+        <!-- Caching -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+
         <!-- DataBase -->
         <dependency>
             <groupId>com.h2database</groupId>
@@ -129,6 +135,20 @@
                     </excludes>
                 </configuration>
             </plugin>
+
+            <!-- This is for redis key in `TimeEntryTrackingServiceImpl#startTrackingTime(Boolean, BigDecimal)`; cuz the key is generating null -->
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-compiler-plugin</artifactId>-->
+<!--                <version>3.11.0</version>-->
+<!--                <configuration>-->
+<!--                    <source>${java.version}</source>-->
+<!--                    <target>${java.version}</target>-->
+<!--                    <compilerArgs>-->
+<!--                        <arg>-parameters</arg>-->
+<!--                    </compilerArgs>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 

--- a/src/main/java/com/seyed/ali/timeentryservice/config/cache/RedisConfiguration.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/config/cache/RedisConfiguration.java
@@ -1,0 +1,52 @@
+package com.seyed.ali.timeentryservice.config.cache;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfiguration {
+
+    /**
+     * Remember to configure the properties in application.yml or properties file.
+     */
+    @Bean
+    @Primary
+    public RedisProperties properties() {
+        return new RedisProperties();
+    }
+
+    /**
+     * Lettuce is non-blocking, and Jedis is blocking.
+     */
+    @Bean
+    public LettuceConnectionFactory lettuceConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(this.properties().getHost());
+        redisStandaloneConfiguration.setPort(this.properties().getPort());
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(this.lettuceConnectionFactory());
+        redisTemplate.setEnableTransactionSupport(true);
+
+        redisTemplate.setKeySerializer(new JdkSerializationRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Object.class));
+
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/seyed/ali/timeentryservice/controller/TimeEntryController.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/controller/TimeEntryController.java
@@ -42,13 +42,23 @@ public class TimeEntryController {
         ));
     }
 
-    @GetMapping("/{userId}")
+    @GetMapping("/user/{userId}")
     public ResponseEntity<Result> getUsersTimeEntry(@PathVariable String userId) {
         return ResponseEntity.ok(new Result(
                 true,
                 OK,
                 "Time entry for user: '" + userId + "' :",
                 this.timeEntryService.getUsersTimeEntry(userId)
+        ));
+    }
+
+    @GetMapping("/{timeEntryId}")
+    public ResponseEntity<Result> getSpecificTimeEntry(@PathVariable String timeEntryId) {
+        return ResponseEntity.ok(new Result(
+                true,
+                OK,
+                "Time entry: '" + timeEntryId + "'.",
+                this.timeEntryService.getTimeEntryById(timeEntryId)
         ));
     }
 

--- a/src/main/java/com/seyed/ali/timeentryservice/controller/TimeEntryController.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/controller/TimeEntryController.java
@@ -1,9 +1,13 @@
 package com.seyed.ali.timeentryservice.controller;
 
+import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
+import com.seyed.ali.timeentryservice.model.domain.TimeSegment;
 import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
 import com.seyed.ali.timeentryservice.model.dto.response.Result;
 import com.seyed.ali.timeentryservice.model.dto.response.TimeEntryResponse;
 import com.seyed.ali.timeentryservice.service.interfaces.TimeEntryService;
+import com.seyed.ali.timeentryservice.util.TimeParser;
+import com.seyed.ali.timeentryservice.util.converter.TimeEntryConverter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 import static org.springframework.http.HttpStatus.*;
 
 @RestController
@@ -24,6 +30,8 @@ import static org.springframework.http.HttpStatus.*;
 public class TimeEntryController {
 
     private final TimeEntryService timeEntryService;
+    private final TimeEntryConverter timeEntryConverter;
+    private final TimeParser timeParser;
 
     @GetMapping
     @Operation(summary = "Get all time entries", responses = {
@@ -34,31 +42,36 @@ public class TimeEntryController {
             )
     })
     public ResponseEntity<Result> getTimeEntries() {
+        List<TimeEntryResponse> timeEntryResponseList = this.timeEntryConverter.convertToTimeEntryResponseList(this.timeEntryService.getTimeEntries());
+
         return ResponseEntity.ok(new Result(
                 true,
                 OK,
                 "List of time entries.",
-                this.timeEntryService.getTimeEntries()
+                timeEntryResponseList
         ));
     }
 
     @GetMapping("/user/{userId}")
     public ResponseEntity<Result> getUsersTimeEntry(@PathVariable String userId) {
+        TimeEntryResponse timeEntryResponse = this.timeEntryConverter.convertToTimeEntryResponse(this.timeEntryService.getUsersTimeEntry(userId));
+
         return ResponseEntity.ok(new Result(
                 true,
                 OK,
                 "Time entry for user: '" + userId + "' :",
-                this.timeEntryService.getUsersTimeEntry(userId)
+                timeEntryResponse
         ));
     }
 
     @GetMapping("/{timeEntryId}")
     public ResponseEntity<Result> getSpecificTimeEntry(@PathVariable String timeEntryId) {
+        TimeEntryResponse timeEntryResponse = this.timeEntryConverter.convertToTimeEntryResponse(this.timeEntryService.getTimeEntryById(timeEntryId));
         return ResponseEntity.ok(new Result(
                 true,
                 OK,
                 "Time entry: '" + timeEntryId + "'.",
-                this.timeEntryService.getTimeEntryById(timeEntryId)
+                timeEntryResponse
         ));
     }
 
@@ -74,11 +87,16 @@ public class TimeEntryController {
 
     @PutMapping("/{timeEntryId}")
     public ResponseEntity<Result> updateTimeEntryManually(@Valid @PathVariable String timeEntryId, @RequestBody TimeEntryDTO timeEntryDTO) {
+        TimeEntry timeEntry = this.timeEntryService.updateTimeEntryManually(timeEntryId, timeEntryDTO);
+        TimeSegment lastTimeSegment = timeEntry.getTimeSegmentList().getLast();
+        String startTimeString = this.timeParser.parseLocalDateTimeToString(lastTimeSegment.getStartTime());
+        TimeEntryDTO timeEntryDTOResponse = this.timeEntryConverter.createTimeEntryDTO(timeEntry, lastTimeSegment, startTimeString);
+
         return ResponseEntity.ok(new Result(
                 true,
                 OK,
                 "Time entry for user: -> " + timeEntryId + " <- updated successfully.",
-                this.timeEntryService.updateTimeEntryManually(timeEntryId, timeEntryDTO)
+                timeEntryDTOResponse
         ));
     }
 

--- a/src/main/java/com/seyed/ali/timeentryservice/controller/TimeEntryTrackingController.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/controller/TimeEntryTrackingController.java
@@ -24,18 +24,11 @@ public class TimeEntryTrackingController {
 
     @PostMapping("/start")
     public ResponseEntity<Result> startTrackingTimeEntry(@Valid @RequestBody TimeBillingDTO timeBillingDTO) {
-        boolean billable = false;
-        BigDecimal hourlyRate = BigDecimal.ZERO;
-
-        if (timeBillingDTO != null) {
-            billable = timeBillingDTO.billable();
-            hourlyRate = timeBillingDTO.hourlyRate();
-        }
         return ResponseEntity.status(CREATED).body(new Result(
                 true,
                 CREATED,
                 "Time tracking started...",
-                this.timeEntryService.startTrackingTimeEntry(billable, hourlyRate)
+                this.timeEntryService.startTrackingTimeEntry(timeBillingDTO)
         ));
     }
 

--- a/src/main/java/com/seyed/ali/timeentryservice/model/domain/TimeEntry.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/model/domain/TimeEntry.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import lombok.*;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class TimeEntry {
+public class TimeEntry implements Serializable {
 
     @Id
     private String timeEntryId;

--- a/src/main/java/com/seyed/ali/timeentryservice/model/domain/TimeSegment.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/model/domain/TimeSegment.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.*;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
@@ -15,7 +16,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class TimeSegment {
+public class TimeSegment implements Serializable {
 
     @Id
     private String timeSegmentId;

--- a/src/main/java/com/seyed/ali/timeentryservice/service/TimeEntryServiceImpl.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/service/TimeEntryServiceImpl.java
@@ -11,6 +11,8 @@ import com.seyed.ali.timeentryservice.util.TimeEntryUtility;
 import com.seyed.ali.timeentryservice.util.TimeParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +44,20 @@ public class TimeEntryServiceImpl implements TimeEntryService {
         TimeEntry timeEntry = this.timeEntryRepository.findByUserId(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User with id " + userId + " not found"));
         return this.timeEntryUtility.convertToTimeEntryResponse(timeEntry);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+//    @Cacheable(
+//            cacheNames = "time-entry-cache",
+//            key = "#timeEntryId"
+//    )
+    public TimeEntryResponse getTimeEntryById(String timeEntryId) {
+        return this.timeEntryRepository.findById(timeEntryId)
+                .map(this.timeEntryUtility::convertToTimeEntryResponse)
+                .orElseThrow(()-> new ResourceNotFoundException("Time entry with ID: '" + timeEntryId +"' was not found."));
     }
 
     /**

--- a/src/main/java/com/seyed/ali/timeentryservice/service/TimeEntryServiceImpl.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/service/TimeEntryServiceImpl.java
@@ -4,13 +4,11 @@ import com.seyed.ali.timeentryservice.exceptions.ResourceNotFoundException;
 import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
 import com.seyed.ali.timeentryservice.model.domain.TimeSegment;
 import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
-import com.seyed.ali.timeentryservice.model.dto.response.TimeEntryResponse;
 import com.seyed.ali.timeentryservice.repository.TimeEntryRepository;
 import com.seyed.ali.timeentryservice.service.cache.TimeEntryCacheManager;
 import com.seyed.ali.timeentryservice.service.interfaces.TimeEntryService;
 import com.seyed.ali.timeentryservice.util.TimeEntryUtility;
 import com.seyed.ali.timeentryservice.util.TimeParser;
-import com.seyed.ali.timeentryservice.util.converter.TimeEntryConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -28,7 +26,6 @@ public class TimeEntryServiceImpl implements TimeEntryService {
     private final TimeEntryRepository timeEntryRepository;
     private final TimeParser timeParser;
     private final TimeEntryUtility timeEntryUtility;
-    private final TimeEntryConverter timeEntryConverter;
     private final TimeEntryCacheManager timeEntryCacheManager;
 
     /**
@@ -56,6 +53,7 @@ public class TimeEntryServiceImpl implements TimeEntryService {
     /**
      * {@inheritDoc}
      */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     @Cacheable(
             cacheNames = TimeEntryCacheManager.TIME_ENTRY_CACHE,
@@ -63,8 +61,11 @@ public class TimeEntryServiceImpl implements TimeEntryService {
             unless = "#result == null"
     )
     public TimeEntry getTimeEntryById(String timeEntryId) {
-        return this.timeEntryRepository.findById(timeEntryId)
+        log.info("Db call.");
+        TimeEntry timeEntry = this.timeEntryRepository.findById(timeEntryId)
                 .orElseThrow(()-> new ResourceNotFoundException("Time entry with ID: '" + timeEntryId +"' was not found."));
+        timeEntry.getTimeSegmentList().size(); // This will initialize the timeSegmentList: otherwise we'll get hibernate's LazyLoadingException.
+        return timeEntry;
     }
 
     /**

--- a/src/main/java/com/seyed/ali/timeentryservice/service/cache/TimeEntryCacheManager.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/service/cache/TimeEntryCacheManager.java
@@ -1,0 +1,21 @@
+package com.seyed.ali.timeentryservice.service.cache;
+
+import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TimeEntryCacheManager {
+
+    public static final String TIME_ENTRY_CACHE = "time-entry-cache";
+
+    @SuppressWarnings("unused")
+    @CachePut(
+            cacheNames = TIME_ENTRY_CACHE,
+            key = "#timeEntryId"
+    )
+    public TimeEntry cacheTimeEntry(String timeEntryId, TimeEntry timeEntry) {
+        return timeEntry;
+    }
+
+}

--- a/src/main/java/com/seyed/ali/timeentryservice/service/cache/TimeEntryCacheManager.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/service/cache/TimeEntryCacheManager.java
@@ -1,9 +1,11 @@
 package com.seyed.ali.timeentryservice.service.cache;
 
 import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class TimeEntryCacheManager {
 
@@ -15,6 +17,7 @@ public class TimeEntryCacheManager {
             key = "#timeEntryId"
     )
     public TimeEntry cacheTimeEntry(String timeEntryId, TimeEntry timeEntry) {
+        log.info("Caching timeEntry. TimeEntryId: {} - UserId: {}", timeEntryId, timeEntry.getUserId());
         return timeEntry;
     }
 

--- a/src/main/java/com/seyed/ali/timeentryservice/service/interfaces/TimeEntryService.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/service/interfaces/TimeEntryService.java
@@ -1,8 +1,8 @@
 package com.seyed.ali.timeentryservice.service.interfaces;
 
 import com.seyed.ali.timeentryservice.exceptions.ResourceNotFoundException;
+import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
 import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
-import com.seyed.ali.timeentryservice.model.dto.response.TimeEntryResponse;
 
 import java.util.List;
 
@@ -16,7 +16,7 @@ public interface TimeEntryService {
      *
      * @return A list of TimeEntryResponse objects representing time entries.
      */
-    List<TimeEntryResponse> getTimeEntries();
+    List<TimeEntry> getTimeEntries();
 
     /**
      * Retrieves a time entry for a specific user.
@@ -25,7 +25,7 @@ public interface TimeEntryService {
      * @return A TimeEntryResponse object representing the user's time entry.
      * @throws ResourceNotFoundException if the user is not found.
      */
-    TimeEntryResponse getUsersTimeEntry(String userId);
+    TimeEntry getUsersTimeEntry(String userId);
 
     /**
      * Retrieves a specific time entry.
@@ -34,7 +34,7 @@ public interface TimeEntryService {
      * @return A TimeEntryResponse object representing the found time entry.
      * @throws ResourceNotFoundException if the time entry is not found.
      */
-    TimeEntryResponse getTimeEntryById(String timeEntryId);
+    TimeEntry getTimeEntryById(String timeEntryId);
 
     /**
      * Adds a new time entry manually.
@@ -52,7 +52,7 @@ public interface TimeEntryService {
      * @return The updated TimeEntryDTO object.
      * @throws IllegalArgumentException if the provided ID does not exist.
      */
-    TimeEntryDTO updateTimeEntryManually(String id, TimeEntryDTO timeEntryDTO);
+    TimeEntry updateTimeEntryManually(String id, TimeEntryDTO timeEntryDTO);
 
     /**
      * Deletes a time entry.

--- a/src/main/java/com/seyed/ali/timeentryservice/service/interfaces/TimeEntryService.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/service/interfaces/TimeEntryService.java
@@ -28,6 +28,15 @@ public interface TimeEntryService {
     TimeEntryResponse getUsersTimeEntry(String userId);
 
     /**
+     * Retrieves a specific time entry.
+     *
+     * @param timeEntryId The ID of the time entry.
+     * @return A TimeEntryResponse object representing the found time entry.
+     * @throws ResourceNotFoundException if the time entry is not found.
+     */
+    TimeEntryResponse getTimeEntryById(String timeEntryId);
+
+    /**
      * Adds a new time entry manually.
      *
      * @param timeEntryDTO The TimeEntryDTO object containing the time entry details.

--- a/src/main/java/com/seyed/ali/timeentryservice/service/interfaces/TimeEntryTrackingService.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/service/interfaces/TimeEntryTrackingService.java
@@ -1,8 +1,7 @@
 package com.seyed.ali.timeentryservice.service.interfaces;
 
+import com.seyed.ali.timeentryservice.model.dto.TimeBillingDTO;
 import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
-
-import java.math.BigDecimal;
 
 /**
  * Interface for Time Entry tracking service operations.
@@ -12,11 +11,10 @@ public interface TimeEntryTrackingService {
     /**
      * Starts tracking a new time entry.
      *
-     * @param billable   A boolean indicating whether the time entry is billable or not.
-     * @param hourlyRate The hourly rate for the time entry (if billable).
+     * @param timeBillingDTO   A dto class with: A boolean indicating whether the time entry is billable or not & The hourly rate for the time entry (if billable).
      * @return The ID of the created time entry.
      */
-    String startTrackingTimeEntry(boolean billable, BigDecimal hourlyRate);
+    String startTrackingTimeEntry(TimeBillingDTO timeBillingDTO);
 
     /**
      * Stops tracking an existing time entry.

--- a/src/main/java/com/seyed/ali/timeentryservice/util/TimeEntryUtility.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/util/TimeEntryUtility.java
@@ -5,16 +5,12 @@ import com.seyed.ali.timeentryservice.exceptions.OperationNotSupportedException;
 import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
 import com.seyed.ali.timeentryservice.model.domain.TimeSegment;
 import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
-import com.seyed.ali.timeentryservice.model.dto.TimeSegmentDTO;
-import com.seyed.ali.timeentryservice.model.dto.response.TimeEntryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,51 +20,6 @@ public class TimeEntryUtility {
 
     private final AuthenticationServiceClient authenticationServiceClient;
     private final TimeParser timeParser;
-
-    /**
-     * Converts a list of TimeEntry objects to a list of TimeEntryResponse objects.
-     *
-     * @param timeEntryList The list of TimeEntry objects to convert.
-     * @return A list of TimeEntryResponse objects.
-     */
-    public List<TimeEntryResponse> convertToTimeEntryResponseList(List<TimeEntry> timeEntryList) {
-        List<TimeEntryResponse> timeEntryResponseList = new ArrayList<>();
-        for (TimeEntry timeEntry : timeEntryList) {
-            TimeEntryResponse timeEntryResponse = this.convertToTimeEntryResponse(timeEntry);
-            timeEntryResponseList.add(timeEntryResponse);
-        }
-        return timeEntryResponseList;
-    }
-
-    /**
-     * Converts a TimeEntry object to a TimeEntryResponse object.
-     *
-     * @param timeEntry The TimeEntry object to convert.
-     * @return A TimeEntryResponse object.
-     */
-    public TimeEntryResponse convertToTimeEntryResponse(TimeEntry timeEntry) {
-        String hourlyRate = timeEntry.getHourlyRate() != null
-                ? timeEntry.getHourlyRate().toString()
-                : null;
-        List<TimeSegmentDTO> timeSegmentDTOList = new ArrayList<>();
-        List<TimeSegment> timeSegmentList = timeEntry.getTimeSegmentList();
-        Duration totalDuration = this.getTotalDuration(timeEntry);
-
-        for (TimeSegment timeSegment : timeSegmentList) {
-            String startTimeStr = this.timeParser.parseLocalDateTimeToString(timeSegment.getStartTime());
-            String endTimeStr = timeSegment.getEndTime() != null
-                    ? this.timeParser.parseLocalDateTimeToString(timeSegment.getEndTime())
-                    : null;
-            String durationStr = timeSegment.getDuration() != null
-                    ? this.timeParser.parseDurationToString(timeSegment.getDuration())
-                    : null;
-            TimeSegmentDTO segmentDTO = new TimeSegmentDTO(timeSegment.getTimeSegmentId(), startTimeStr, endTimeStr, durationStr, timeEntry.getUserId());
-            timeSegmentDTOList.add(segmentDTO);
-        }
-
-        String totalDurationStr = this.timeParser.parseDurationToString(totalDuration);
-        return new TimeEntryResponse(timeEntry.getTimeEntryId(), timeSegmentDTOList, timeEntry.isBillable(), hourlyRate, totalDurationStr);
-    }
 
     /**
      * Creates a new TimeEntry object based on the provided TimeEntryDTO.
@@ -206,21 +157,6 @@ public class TimeEntryUtility {
                 .duration(calculatedDuration)
                 .timeEntry(timeEntry)
                 .build();
-    }
-
-    /**
-     * Creates a TimeEntryDTO object based on the provided TimeEntry and TimeSegment objects.
-     *
-     * @param timeEntry       The TimeEntry object.
-     * @param lastTimeSegment The last TimeSegment object associated with the time entry.
-     * @param startTimeString The start time string for the time entry.
-     * @return The created TimeEntryDTO object.
-     */
-    public TimeEntryDTO createTimeEntryDTO(TimeEntry timeEntry, TimeSegment lastTimeSegment, String startTimeString) {
-        String hourlyRate = timeEntry.getHourlyRate() != null ? timeEntry.getHourlyRate().toString() : null;
-        String endTimeStr = timeParser.parseLocalDateTimeToString(lastTimeSegment.getEndTime());
-        String durationStr = timeParser.parseDurationToString(lastTimeSegment.getDuration());
-        return new TimeEntryDTO(timeEntry.getTimeEntryId(), startTimeString, endTimeStr, timeEntry.isBillable(), hourlyRate, durationStr);
     }
 
     /**

--- a/src/main/java/com/seyed/ali/timeentryservice/util/TimeEntryUtility.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/util/TimeEntryUtility.java
@@ -56,8 +56,12 @@ public class TimeEntryUtility {
 
         for (TimeSegment timeSegment : timeSegmentList) {
             String startTimeStr = this.timeParser.parseLocalDateTimeToString(timeSegment.getStartTime());
-            String endTimeStr = this.timeParser.parseLocalDateTimeToString(timeSegment.getEndTime());
-            String durationStr = this.timeParser.parseDurationToString(timeSegment.getDuration());
+            String endTimeStr = timeSegment.getEndTime() != null
+                    ? this.timeParser.parseLocalDateTimeToString(timeSegment.getEndTime())
+                    : null;
+            String durationStr = timeSegment.getDuration() != null
+                    ? this.timeParser.parseDurationToString(timeSegment.getDuration())
+                    : null;
             TimeSegmentDTO segmentDTO = new TimeSegmentDTO(timeSegment.getTimeSegmentId(), startTimeStr, endTimeStr, durationStr, timeEntry.getUserId());
             timeSegmentDTOList.add(segmentDTO);
         }

--- a/src/main/java/com/seyed/ali/timeentryservice/util/converter/TimeEntryConverter.java
+++ b/src/main/java/com/seyed/ali/timeentryservice/util/converter/TimeEntryConverter.java
@@ -1,0 +1,87 @@
+package com.seyed.ali.timeentryservice.util.converter;
+
+import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
+import com.seyed.ali.timeentryservice.model.domain.TimeSegment;
+import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
+import com.seyed.ali.timeentryservice.model.dto.TimeSegmentDTO;
+import com.seyed.ali.timeentryservice.model.dto.response.TimeEntryResponse;
+import com.seyed.ali.timeentryservice.util.TimeEntryUtility;
+import com.seyed.ali.timeentryservice.util.TimeParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+// TODO: Write unit tests!
+@Service
+@RequiredArgsConstructor
+public class TimeEntryConverter {
+
+    private final TimeParser timeParser;
+    private final TimeEntryUtility timeEntryUtility;
+
+    /**
+     * Converts a list of TimeEntry objects to a list of TimeEntryResponse objects.
+     *
+     * @param timeEntryList The list of TimeEntry objects to convert.
+     * @return A list of TimeEntryResponse objects.
+     */
+    public List<TimeEntryResponse> convertToTimeEntryResponseList(List<TimeEntry> timeEntryList) {
+        List<TimeEntryResponse> timeEntryResponseList = new ArrayList<>();
+        for (TimeEntry timeEntry : timeEntryList) {
+            TimeEntryResponse timeEntryResponse = this.convertToTimeEntryResponse(timeEntry);
+            timeEntryResponseList.add(timeEntryResponse);
+        }
+        return timeEntryResponseList;
+    }
+
+    /**
+     * Converts a TimeEntry object to a TimeEntryResponse object.
+     *
+     * @param timeEntry The TimeEntry object to convert.
+     * @return A TimeEntryResponse object.
+     */
+    public TimeEntryResponse convertToTimeEntryResponse(TimeEntry timeEntry) {
+        String hourlyRate = timeEntry.getHourlyRate() != null
+                ? timeEntry.getHourlyRate().toString()
+                : null;
+        List<TimeSegmentDTO> timeSegmentDTOList = new ArrayList<>();
+        List<TimeSegment> timeSegmentList = timeEntry.getTimeSegmentList();
+        Duration totalDuration = this.timeEntryUtility.getTotalDuration(timeEntry);
+
+        for (TimeSegment timeSegment : timeSegmentList) {
+            String startTimeStr = this.timeParser.parseLocalDateTimeToString(timeSegment.getStartTime());
+            String endTimeStr = timeSegment.getEndTime() != null
+                    ? this.timeParser.parseLocalDateTimeToString(timeSegment.getEndTime())
+                    : null;
+            String durationStr = timeSegment.getDuration() != null
+                    ? this.timeParser.parseDurationToString(timeSegment.getDuration())
+                    : null;
+            TimeSegmentDTO segmentDTO = new TimeSegmentDTO(timeSegment.getTimeSegmentId(), startTimeStr, endTimeStr, durationStr, timeEntry.getUserId());
+            timeSegmentDTOList.add(segmentDTO);
+        }
+
+        String totalDurationStr = this.timeParser.parseDurationToString(totalDuration);
+        return new TimeEntryResponse(timeEntry.getTimeEntryId(), timeSegmentDTOList, timeEntry.isBillable(), hourlyRate, totalDurationStr);
+    }
+
+    /**
+     * Creates a TimeEntryDTO object based on the provided TimeEntry and TimeSegment objects.
+     *
+     * @param timeEntry       The TimeEntry object.
+     * @param lastTimeSegment The last TimeSegment object associated with the time entry.
+     * @param startTimeString The start time string for the time entry.
+     * @return The created TimeEntryDTO object.
+     */
+    public TimeEntryDTO createTimeEntryDTO(TimeEntry timeEntry, TimeSegment lastTimeSegment, String startTimeString) {
+        String hourlyRate = timeEntry.getHourlyRate() != null
+                ? timeEntry.getHourlyRate().toString()
+                : null;
+        String endTimeStr = this.timeParser.parseLocalDateTimeToString(lastTimeSegment.getEndTime());
+        String durationStr = this.timeParser.parseDurationToString(lastTimeSegment.getDuration());
+        return new TimeEntryDTO(timeEntry.getTimeEntryId(), startTimeString, endTimeStr, timeEntry.isBillable(), hourlyRate, durationStr);
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -44,6 +44,20 @@ spring:
         jwt:
           issuer-uri: http://${KEYCLOAK_SERVER_HOST:localhost}:8080/realms/DevVault-v2.0
 
+--- # Redis
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+  cache:
+    type: redis
+    cache-names:
+      - time-entry-cache
+    redis:
+      cache-null-values: true
+      time-to-live: ${REDIS_CACHE_TIME_TO_LIVE:600000} # 1 hour
+
 --- # Swagger
 springdoc:
   swagger-ui:

--- a/src/test/java/com/seyed/ali/timeentryservice/controller/TimeEntryControllerTest.java
+++ b/src/test/java/com/seyed/ali/timeentryservice/controller/TimeEntryControllerTest.java
@@ -135,7 +135,7 @@ class TimeEntryControllerTest {
 
         // When
         ResultActions resultActions = this.mockMvc.perform(
-                MockMvcRequestBuilders.get(this.baseUrl + "/" + userId)
+                MockMvcRequestBuilders.get(this.baseUrl + "/user/" + userId)
                         .accept(APPLICATION_JSON)
                         .with(jwt().authorities(new SimpleGrantedAuthority(some_authority)))
         );

--- a/src/test/java/com/seyed/ali/timeentryservice/controller/TimeEntryTrackingControllerTest.java
+++ b/src/test/java/com/seyed/ali/timeentryservice/controller/TimeEntryTrackingControllerTest.java
@@ -60,7 +60,7 @@ class TimeEntryTrackingControllerTest {
     public void startTrackingTimeEntryTest() throws Exception {
         // given
         String timeEntryId = "some_time_entry_id";
-        when(this.timeEntryTrackingService.startTrackingTimeEntry(isA(Boolean.class), isA(BigDecimal.class)))
+        when(this.timeEntryTrackingService.startTrackingTimeEntry(isA(TimeBillingDTO.class)))
                 .thenReturn(timeEntryId);
         String json = this.objectMapper.writeValueAsString(new TimeBillingDTO(true, BigDecimal.ONE));
 

--- a/src/test/java/com/seyed/ali/timeentryservice/service/TimeEntryTrackingServiceImplTest.java
+++ b/src/test/java/com/seyed/ali/timeentryservice/service/TimeEntryTrackingServiceImplTest.java
@@ -3,6 +3,7 @@ package com.seyed.ali.timeentryservice.service;
 import com.seyed.ali.timeentryservice.client.AuthenticationServiceClient;
 import com.seyed.ali.timeentryservice.model.domain.TimeEntry;
 import com.seyed.ali.timeentryservice.model.domain.TimeSegment;
+import com.seyed.ali.timeentryservice.model.dto.TimeBillingDTO;
 import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
 import com.seyed.ali.timeentryservice.repository.TimeEntryRepository;
 import com.seyed.ali.timeentryservice.util.TimeEntryUtility;
@@ -84,7 +85,8 @@ class TimeEntryTrackingServiceImplTest extends TimeParserUtilForTests {
         when(this.timeEntryRepository.save(isA(TimeEntry.class))).thenReturn(timeEntry);
 
         // Act
-        String timeEntryId = this.timeEntryTrackingService.startTrackingTimeEntry(false, BigDecimal.ONE);
+        TimeBillingDTO timeBillingDTO = new TimeBillingDTO(false, BigDecimal.ZERO);
+        String timeEntryId = this.timeEntryTrackingService.startTrackingTimeEntry(timeBillingDTO);
         System.out.println(timeEntryId);
 
         // Assert

--- a/src/test/java/com/seyed/ali/timeentryservice/service/TimeEntryTrackingServiceImplTest.java
+++ b/src/test/java/com/seyed/ali/timeentryservice/service/TimeEntryTrackingServiceImplTest.java
@@ -6,6 +6,7 @@ import com.seyed.ali.timeentryservice.model.domain.TimeSegment;
 import com.seyed.ali.timeentryservice.model.dto.TimeBillingDTO;
 import com.seyed.ali.timeentryservice.model.dto.TimeEntryDTO;
 import com.seyed.ali.timeentryservice.repository.TimeEntryRepository;
+import com.seyed.ali.timeentryservice.service.cache.TimeEntryCacheManager;
 import com.seyed.ali.timeentryservice.util.TimeEntryUtility;
 import com.seyed.ali.timeentryservice.util.TimeParser;
 import com.seyed.ali.timeentryservice.util.TimeParserUtilForTests;
@@ -36,6 +37,7 @@ class TimeEntryTrackingServiceImplTest extends TimeParserUtilForTests {
     private @Mock AuthenticationServiceClient authenticationServiceClient;
     private @Mock TimeParser timeParser;
     private @Mock TimeEntryUtility timeEntryUtility;
+    private @Mock TimeEntryCacheManager timeEntryCacheManager;
 
     private String startTimeStr;
     private String endTimeStr;
@@ -83,6 +85,7 @@ class TimeEntryTrackingServiceImplTest extends TimeParserUtilForTests {
         when(this.timeEntryUtility.createNewTimeEntry(isA(Boolean.class), isA(BigDecimal.class), isA(AuthenticationServiceClient.class)))
                 .thenReturn(this.timeEntry);
         when(this.timeEntryRepository.save(isA(TimeEntry.class))).thenReturn(timeEntry);
+        when(this.timeEntryCacheManager.cacheTimeEntry(isA(String.class), isA(TimeEntry.class))).thenReturn(this.timeEntry);
 
         // Act
         TimeBillingDTO timeBillingDTO = new TimeBillingDTO(false, BigDecimal.ZERO);
@@ -132,6 +135,8 @@ class TimeEntryTrackingServiceImplTest extends TimeParserUtilForTests {
                     return dateTime.format(formatter);
                 });
         when(this.timeParser.parseDurationToString(any(Duration.class))).thenReturn(duration.toString());
+        when(this.timeEntryRepository.save(isA(TimeEntry.class))).thenReturn(this.timeEntry);
+        when(this.timeEntryCacheManager.cacheTimeEntry(isA(String.class), isA(TimeEntry.class))).thenReturn(this.timeEntry);
 
         // Act
         TimeEntryDTO result = this.timeEntryTrackingService.stopTrackingTimeEntry(timeEntry.getTimeEntryId());
@@ -171,6 +176,7 @@ class TimeEntryTrackingServiceImplTest extends TimeParserUtilForTests {
         when(this.timeEntryRepository.save(isA(TimeEntry.class))).thenReturn(timeEntry);
         when(this.timeParser.parseLocalDateTimeToString(isA(LocalDateTime.class)))
                 .thenReturn(formattedContinueTimeStr);
+        when(this.timeEntryCacheManager.cacheTimeEntry(isA(String.class), isA(TimeEntry.class))).thenReturn(this.timeEntry);
 
         // Act
         TimeEntryDTO result = this.timeEntryTrackingService.continueTrackingTimeEntry(timeEntryId);


### PR DESCRIPTION
Fix: Resolved LazyInitializationException in TimeEntry retrieval. (Close #13)

# Issue
We encountered a `LazyInitializationException` when trying to access the `timeSegmentList` of a `TimeEntry` object that was retrieved from the cache. This happened because the `timeSegmentList` was lazily loaded by Hibernate, and we were trying to access it after the Hibernate Session had been closed.

# Temporary Solution
We resolved this issue by forcing the initialization of the `timeSegmentList` before caching the `TimeEntry` object. We did this by calling `size()` on the `timeSegmentList` in the `getTimeEntryById` method. This ensured that the list was fetched from the database and included in the cached `TimeEntry`.

```java
timeEntry.getTimeSegmentList().size(); // This will initialize the timeSegmentList
```
> # Note
>  This solution might have performance implications if the timeSegmentList is large, as it will always be fetched from the database even if it’s not needed. Therefore, this solution is not recommended for large data sets. We are currently exploring more efficient solutions.
